### PR TITLE
Implement BiCGStab

### DIFF
--- a/src/KrylovKit.jl
+++ b/src/KrylovKit.jl
@@ -29,7 +29,7 @@ export initialize, initialize!, expand!, shrink!
 export ClassicalGramSchmidt, ClassicalGramSchmidt2, ClassicalGramSchmidtIR
 export ModifiedGramSchmidt, ModifiedGramSchmidt2, ModifiedGramSchmidtIR
 export LanczosIterator, ArnoldiIterator, GKLIterator
-export CG, GMRES, Lanczos, Arnoldi, GKL, GolubYe
+export CG, GMRES, BiCGStab, Lanczos, Arnoldi, GKL, GolubYe
 export KrylovDefaults, ClosestTo, EigSorter
 export RecursiveVec, InnerProductVec
 
@@ -344,6 +344,7 @@ include("eigsolve/svdsolve.jl")
 include("linsolve/linsolve.jl")
 include("linsolve/cg.jl")
 include("linsolve/gmres.jl")
+include("linsolve/bicgstab.jl")
 
 # exponentiate
 include("matrixfun/exponentiate.jl")

--- a/src/linsolve/bicgstab.jl
+++ b/src/linsolve/bicgstab.jl
@@ -1,0 +1,217 @@
+function linsolve(operator, b, x₀, alg::BiCGStab, a₀::Number=0, a₁::Number=1)
+    # Initial function operation and division defines number type
+    y₀ = apply(operator, x₀)
+    T = typeof(dot(b, y₀) / norm(b) * one(a₀) * one(a₁))
+    α₀ = convert(T, a₀)
+    α₁ = convert(T, a₁)
+    # Continue computing r = b - a₀ * x₀ - a₁ * operator(x₀)
+    r = one(T)*b # r = mul!(similar(b, T), b, 1)
+    r = iszero(α₀) ? r : axpy!(-α₀, x₀, r)
+    r = axpy!(-α₁, y₀, r)
+    x = mul!(similar(r), x₀, 1)
+    normr = norm(r)
+    S = typeof(normr)
+    
+    # Algorithm parameters
+    maxiter = alg.maxiter
+    tol::S = alg.tol
+    numops = 1 # operator has been applied once to determine r
+    numiter = 0
+    
+    # Check for early return
+    if normr < tol
+        if alg.verbosity > 0
+            @info """BiCGStab linsolve converged without any iterations:
+             *  norm of residual = $normr
+             *  number of operations = 1"""
+        end
+        return (x, ConvergenceInfo(1, r, normr, numiter, numops))
+    end
+    
+    # First iteration
+    numiter += 1
+    r_shadow = mul!(similar(r), r, 1)     # shadow residual
+    ρ = dot(r_shadow, r)
+    
+    # Method fails if ρ is zero.
+    if ρ ≈ 0.0
+        @warn """BiCGStab linsolve errored after $numiter iterations:
+        *   norm of residual = $normr
+        *   number of operations = $numops"""
+        return (x, ConvergenceInfo(0, r, normr, numiter, numops))
+    end
+    
+    ## BiCG part of the algorithm.
+    p = mul!(similar(r), r, 1)
+    v = do_apply!(operator, α₀, α₁, p)
+    numops += 1
+    
+    σ = dot(r_shadow, v)
+    α = ρ / σ
+    
+    s = mul!(similar(r), r, 1)
+    axpy!(-α, v, s)  # half step residual
+    
+    xhalf = mul!(similar(x), x, 1)
+    axpy!(+α, p, xhalf) # half step iteration
+    
+    normr = norm(s)
+    
+    # Check for early return at half step.
+    if normr < tol
+        # Replace approximate residual with the actual residual.
+        s = mul!(similar(b), b, 1)
+        axpy!(-1, do_apply!(operator, α₀, α₁, xhalf), s) 
+        numops += 1
+        
+        normr_act = norm(s)
+        if normr_act < tol
+            if alg.verbosity > 0
+                @info """BiCGStab linsolve converged at iteration $(numiter-1/2):
+                 *  norm of residual = $normr_act
+                 *  number of operations = $numops"""
+            end
+            return (xhalf, ConvergenceInfo(1, s, normr_act, numiter, numops))
+        end
+    end
+    
+    ## GMRES part of the algorithm.
+    t = do_apply!(operator, α₀, α₁, s)
+    numops += 1
+    
+    ω = dot(t, s) / dot(t, t)
+    
+    mul!(x, xhalf, 1)
+    axpy!(+ω, s, x)    # full step iteration
+    
+    mul!(r, s, 1)
+    axpy!(-ω, t, r)      # full step residual
+    
+    # Check for early return at full step.
+    normr = norm(r)
+    if normr < tol
+        # Replace approximate residual with the actual residual.
+        mul!(r, b, 1)
+        axpy!(-1, do_apply!(operator, α₀, α₁, x), r)
+        numops += 1
+        
+        
+        normr_act = norm(r)
+        if normr_act < tol
+            if alg.verbosity > 0
+                @info """BiCGStab linsolve converged at iteration $(numiter):
+                *  norm of residual = $normr_act
+                *  number of operations = $numops"""
+            end
+            return (x, ConvergenceInfo(1, r, normr_act, numiter, numops))
+        end
+    end
+    
+    while numiter < maxiter
+        if alg.verbosity > 0
+            msg = "BiCGStab linsolve in iter $numiter: "
+            msg *= "normres = "
+            msg *= @sprintf("%12e", normr)
+            @info msg
+        end
+        
+        numiter += 1
+        ρold = ρ
+        ρ = dot(r_shadow, r)
+        β = (ρ / ρold) * (α / ω)
+        
+        axpy!(-ω, v, p)
+        axpby!(1, r, β, p)
+        
+        v = do_apply!(operator, α₀, α₁, p)
+        numops += 1
+        
+        σ = dot(r_shadow, v)
+        α = ρ / σ
+        
+        s = mul!(s, r, 1)
+        s = axpy!(-α, v, s)     # half step residual
+        
+        xhalf = mul!(xhalf, x, 1)
+        xhalf = axpy!(+α, p, xhalf)     # half step iteration
+        
+        normr = norm(s)
+        
+        if alg.verbosity > 0
+            msg = "BiCGStab linsolve in iter $(numiter-1/2): "
+            msg *= "normres = "
+            msg *= @sprintf("%12e", normr)
+            @info msg
+        end        
+        
+        # Check for return at half step.
+        if normr < tol
+            # Compute non-approximate residual.
+            #= s = mul!(similar(b), b, 1)
+            s = iszero(α₀) ? s : axpy!(-α₀, xhalf, s)
+            axpy!(-α₁, apply(operator, xhalf), s)
+            numops += 1 =#
+            s = mul!(similar(b), b, 1)
+            axpy!(-1, do_apply!(operator, α₀, α₁, xhalf), s) 
+            numops += 1
+            
+            normr_act = norm(s)
+            if normr_act < tol
+                if alg.verbosity > 0
+                    @info """BiCGStab linsolve converged at iteration $(numiter-1/2):
+                    *  norm of residual = $normr_act
+                    *  number of operations = $numops"""
+                end
+                return (xhalf, ConvergenceInfo(1, s, normr_act, numiter, numops))
+            end
+        end
+        
+        
+        ## GMRES part of the algorithm.
+        t = do_apply!(operator, α₀, α₁, s)
+        numops += 1
+        
+        ω = dot(t, s) / dot(t, t)
+        
+        mul!(x, xhalf, 1)
+        axpy!(+ω, s, x)    # full step iteration
+        
+        mul!(r, s, 1)
+        axpy!(-ω, t, r)    # full step residual
+        
+        # Check for return at full step.
+        normr = norm(r)
+        if normr < tol
+            # Replace approximate residual with the actual residual.
+            mul!(r, b, 1)
+            axpy!(-1, do_apply!(operator, α₀, α₁, x), r)
+            numops += 1
+            
+            normr_act = norm(r)
+            if normr_act < tol
+                if alg.verbosity > 0
+                    @info """BiCGStab linsolve converged at iteration $(numiter):
+                    *  norm of residual = $normr_act
+                    *  number of operations = $numops"""
+                end
+                return (x, ConvergenceInfo(1, r, normr_act, numiter, numops))
+            end
+        end
+    end
+    
+    if alg.verbosity > 0
+        @warn """BiCGStab linsolve finished without converging after $numiter iterations:
+        *   norm of residual = $normr
+        *   number of operations = $numops"""
+    end
+    return (x, ConvergenceInfo(0, r, normr, numiter, numops))
+end
+
+function do_apply!(operator, α₀, α₁, x)
+    y = apply(operator, x)
+    if α₀ != zero(α₀) || α₁ != one(α₁)
+        axpby!(α₀, x, α₁, y)
+    end
+
+    return y
+end

--- a/test/linsolve.jl
+++ b/test/linsolve.jl
@@ -73,3 +73,22 @@ end
         @test b ≈ (α₀*I+α₁*A)*unwrapvec(x) + unwrapvec(info.residual)
     end
 end
+
+# Test BICGStab
+@testset "BiCGStab" begin
+    @testset for T in (Float32, Float64, ComplexF32, ComplexF64)
+        A = rand(T,(N,N)).-one(T)/2
+        A = I-T(9/10)*A/maximum(abs, eigvals(A))
+        b = rand(T,N)
+        alg = BiCGStab(; maxiter=2N, tol=10N*eps(real(T))*norm(b))
+        x, info = @inferred linsolve(wrapop(A), wrapvec(b), wrapvec(zero(b)), alg)
+        @test b ≈ A*unwrapvec(x)
+
+        A = rand(T,(N,N)).-one(T)/2
+        α₀ = maximum(abs, eigvals(A))
+        α₁ = -rand(T)
+        α₁ *= T(9)/T(10)/abs(α₁)
+        x, info = @inferred linsolve(wrapop(A), wrapvec(b), wrapvec(zero(b)), alg, α₀, α₁)
+        @test b ≈ (α₀*I+α₁*A)*unwrapvec(x) # + unwrapvec(info.residual)
+    end
+end


### PR DESCRIPTION
First implementation of BiCGStab, preliminary benchmarks seem to indicate comparable performance to GMRES, however this is dependent on a lot of parameters (Krylovdimension, operator size, specific operator, ...) and thus this is not a quantitative test.

> 
> ```julia-repl
> ##############################################
> 10 
> ####################
> GMRES{ModifiedGramSchmidt2, Float64}(ModifiedGramSchmidt2(), 2, 10, 1.2696590058460974e-14, 0)
> BechmarkTools.Trial: 10000 samples with 1 evaluations.
>  Range (min … max):  33.959 μs …  4.468 ms  ┊ GC (min … max): 0.00% … 97.31%
>  Time  (median):     38.578 μs              ┊ GC (median):    0.00%
>  Time  (mean ± σ):   42.177 μs ± 84.703 μs  ┊ GC (mean ± σ):  4.40% ±  2.18%
> 
>       █▅▇▁▃                                                    
>   ▃▇▇██████▆▅▄▄▃▃▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
>   34 μs           Histogram: frequency by time        76.5 μs <
> 
>  Memory estimate: 21.92 KiB, allocs estimate: 371.
> 
> 
> 
> 
> GMRES{ModifiedGramSchmidt2, Float64}(ModifiedGramSchmidt2(), 50, 30, 1.2696590058460974e-14, 0)
> BechmarkTools.Trial: 10000 samples with 1 evaluations.
>  Range (min … max):  34.969 μs …  2.955 ms  ┊ GC (min … max): 0.00% … 97.67%
>  Time  (median):     36.582 μs              ┊ GC (median):    0.00%
>  Time  (mean ± σ):   41.049 μs ± 80.944 μs  ┊ GC (mean ± σ):  5.42% ±  2.75%
> 
>   ▅██▇▆▄▂▂▁▁▂▁▂▁▂▂▂▃▂▂▂▁▁▁▁                                   ▂
>   ██████████████████████████▇▇▇▆▅▅▄▅▄▄▃▅▅▄▁▄▃▁▄▅▅▅▅▅▅▅▅▅▆▅▆▅▆ █
>   35 μs        Histogram: log(frequency) by time      68.3 μs <
> 
>  Memory estimate: 36.00 KiB, allocs estimate: 371.
> 
> 
> 
> 
> BiCGStab{Float64}(1500, 1.2696590058460974e-14, 0)
> BechmarkTools.Trial: 10000 samples with 1 evaluations.
>  Range (min … max):  38.888 μs …  3.081 ms  ┊ GC (min … max): 0.00% … 97.93%
>  Time  (median):     39.798 μs              ┊ GC (median):    0.00%
>  Time  (mean ± σ):   42.926 μs ± 66.868 μs  ┊ GC (mean ± σ):  3.45% ±  2.19%
> 
>    ▆██▆▅▃▂               ▁▁▂▂▂▂▂▂▁ ▁▁             ▁▁          ▂
>   █████████▇▆▆▆▆▇███▇▆████████████████▇▇▇▇██▇▆▆▇████▇▇▇▆▇▇▇▇▆ █
>   38.9 μs      Histogram: log(frequency) by time      54.3 μs <
> 
>  Memory estimate: 23.17 KiB, allocs estimate: 486.
> 
> 
> 
> 
> ##############################################
> 100 
> ####################
> GMRES{ModifiedGramSchmidt2, Float64}(ModifiedGramSchmidt2(), 2, 100, 3.5471700924607985e-13, 0)
> BechmarkTools.Trial: 1654 samples with 1 evaluations.
>  Range (min … max):  2.784 ms …   7.459 ms  ┊ GC (min … max): 0.00% … 40.83%
>  Time  (median):     2.858 ms               ┊ GC (median):    0.00%
>  Time  (mean ± σ):   3.016 ms ± 535.550 μs  ┊ GC (mean ± σ):  2.64% ±  7.97%
> 
>   █▇▆▄▃▁▂▁▁▁                                                   
>   ██████████▇▆█▆▇▇▇▆▅▄▁▄▄▆▁▅▄▄▄▅▁▄▁▄▄▅▄▆▁▁▁▁▄▅▄▄▁▁▁▁▁▁▁▁▁▆▇▇▇ █
>   2.78 ms      Histogram: log(frequency) by time      5.61 ms <
> 
>  Memory estimate: 1.32 MiB, allocs estimate: 16807.
> 
> 
> 
> 
> GMRES{ModifiedGramSchmidt2, Float64}(ModifiedGramSchmidt2(), 50, 30, 3.5471700924607985e-13, 0)
> BechmarkTools.Trial: 246 samples with 1 evaluations.
>  Range (min … max):  18.958 ms … 31.952 ms  ┊ GC (min … max): 0.00% … 9.95%
>  Time  (median):     19.532 ms              ┊ GC (median):    0.00%
>  Time  (mean ± σ):   20.311 ms ±  1.897 ms  ┊ GC (mean ± σ):  2.55% ± 4.59%
> 
>   ▅█▃▁                                                         
>   ████▆▄▅▃▃▂▃▁▁▃▅▅▄▄▃▃▂▂▂▁▁▁▂▁▁▃▁▃▁▁▁▁▁▁▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃ ▃
>   19 ms           Histogram: frequency by time          30 ms <
> 
>  Memory estimate: 9.01 MiB, allocs estimate: 98746.
> 
> 
> 
> 
> BiCGStab{Float64}(1500, 3.5471700924607985e-13, 0)
> BechmarkTools.Trial: 402 samples with 1 evaluations.
>  Range (min … max):  11.592 ms …  17.670 ms  ┊ GC (min … max): 0.00% … 0.00%
>  Time  (median):     12.145 ms               ┊ GC (median):    0.00%
>  Time  (mean ± σ):   12.453 ms ± 871.056 μs  ┊ GC (mean ± σ):  1.87% ± 4.27%
> 
>     ▁▁█▄▁▂▄                                                     
>   ▃▅████████▅▅▅▄▄▂▃▃▃▃▁▃▃▃▁▃▃▃▃▄▆▃▃▃▃▃▂▁▁▂▂▁▂▁▃▁▁▂▁▁▁▁▁▃▁▁▁▁▁▂ ▃
>   11.6 ms         Histogram: frequency by time         15.9 ms <
> 
>  Memory estimate: 5.96 MiB, allocs estimate: 33029.
> 
> 
> 
> 
> ##############################################
> 1000 
> ####################
> GMRES{ModifiedGramSchmidt2, Float64}(ModifiedGramSchmidt2(), 2, 1000, 1.1154523617852167e-11, 0)
> BechmarkTools.Trial: 3 samples with 1 evaluations.
>  Range (min … max):  2.122 s …   2.173 s  ┊ GC (min … max): 0.27% … 0.24%
>  Time  (median):     2.137 s              ┊ GC (median):    0.27%
>  Time  (mean ± σ):   2.144 s ± 26.256 ms  ┊ GC (mean ± σ):  0.31% ± 0.10%
> 
>   █               █                                       ██ 
>   █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
>   2.12 s         Histogram: frequency by time        2.17 s <
> 
>  Memory estimate: 109.16 MiB, allocs estimate: 1878943.
> 
> 
> 
> 
> GMRES{ModifiedGramSchmidt2, Float64}(ModifiedGramSchmidt2(), 50, 30, 1.1154523617852167e-11, 0)
> BechmarkTools.Trial: 16 samples with 1 evaluations.
>  Range (min … max):  317.520 ms … 347.255 ms  ┊ GC (min … max): 0.50% … 0.46%
>  Time  (median):     321.755 ms               ┊ GC (median):    0.49%
>  Time  (mean ± σ):   326.272 ms ±   9.941 ms  ┊ GC (mean ± σ):  0.55% ± 0.17%
> 
>    █                                                             
>   ▇█▇▁▁▇▇▁▇▇▁▇▁▁▇▁▁▁▁▁▁▁▁▁▁▁▁▇▁▁▁▁▁▁▁▁▇▁▁▁▁▁▁▇▁▁▁▁▁▁▁▁▁▁▁▁▇▁▁▁▇ ▁
>   318 ms           Histogram: frequency by time          347 ms <
> 
>  Memory estimate: 50.04 MiB, allocs estimate: 98746.
> 
> 
> 
> 
> BiCGStab{Float64}(1500, 1.1154523617852167e-11, 0)
> BechmarkTools.Trial: 11 samples with 1 evaluations.
>  Range (min … max):  458.184 ms … 511.958 ms  ┊ GC (min … max): 0.29% … 0.26%
>  Time  (median):     480.803 ms               ┊ GC (median):    0.28%
>  Time  (mean ± σ):   486.912 ms ±  18.079 ms  ┊ GC (mean ± σ):  0.28% ± 0.01%
> 
>   ▁              █▁      ▁ ▁               ▁       ▁▁        ▁▁▁ 
>   █▁▁▁▁▁▁▁▁▁▁▁▁▁▁██▁▁▁▁▁▁█▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁██▁▁▁▁▁▁▁▁██ ▁
>   458 ms           Histogram: frequency by time          512 ms <
> 
>  Memory estimate: 47.03 MiB, allocs estimate: 33029.
> 
> ```