### PR TITLE
Reuse initial apply in expintegrator

### DIFF
--- a/src/matrixfun/expintegrator.jl
+++ b/src/matrixfun/expintegrator.jl
@@ -136,7 +136,7 @@ function expintegrator(A, t::Number, u::Tuple, alg::Union{Lanczos,Arnoldi})
     # initial vectors
     w = Vector{typeof(w₀)}(undef, p + 1)
     w[1] = w₀
-    w[2] = one(T) * Au₀
+    w[2] = one(T) * Au₀ # reuse the result of apply computed earlier
     for j in 1:p
         if j > 1
           w[j+1] = apply(A, w[j])

--- a/src/matrixfun/expintegrator.jl
+++ b/src/matrixfun/expintegrator.jl
@@ -136,9 +136,12 @@ function expintegrator(A, t::Number, u::Tuple, alg::Union{Lanczos,Arnoldi})
     # initial vectors
     w = Vector{typeof(w₀)}(undef, p + 1)
     w[1] = w₀
+    w[2] = one(T) * Au₀
     for j in 1:p
-        w[j+1] = apply(A, w[j])
-        numops += 1
+        if j > 1
+          w[j+1] = apply(A, w[j])
+          numops += 1
+        end
         lfac = 1
         for l in 0:p-j
             w[j+1] = axpy!((sgn * τ₀)^l / lfac, u[j+l+1], w[j+1])

--- a/src/matrixfun/expintegrator.jl
+++ b/src/matrixfun/expintegrator.jl
@@ -136,7 +136,8 @@ function expintegrator(A, t::Number, u::Tuple, alg::Union{Lanczos,Arnoldi})
     # initial vectors
     w = Vector{typeof(w₀)}(undef, p + 1)
     w[1] = w₀
-    w[2] = one(T) * Au₀ # reuse the result of apply computed earlier
+    # reuse the result of apply computed earlier:
+    w[2] = mul!(similar(w₀), Au₀, one(T))
     for j in 1:p
         if j > 1
           w[j+1] = apply(A, w[j])


### PR DESCRIPTION
At the beginning of `expintegrator`, apply is called to apply the linear map for the purpose of determining the type `T` of other variables. However, the result is not used later in the code. This PR uses the result to start building the vectors `w`, saving one call to apply while giving exactly the same results. This could lead to a significant performance increase in cases where only a few Krylov vectors are computed, such as for small time steps.
