### PR TITLE
Fix and test for issue 100

### DIFF
--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1,0 +1,19 @@
+# https://github.com/Jutho/KrylovKit.jl/issues/100
+@testset "Issue #100" begin
+    N = 32 # needs to be large enough to trigger shrinking
+    A = rand(N, N)
+    A += A'
+    v₀ = [rand(N ÷ 2), rand(N ÷ 2)]
+
+    vals, vecs, = eigsolve(v₀, 4, :LM; ishermitian=true) do v
+        v′ = vcat(v...)
+        y = A * v′
+        return [y[1:(N ÷ 2)], y[(N ÷ 2 + 1):end]]
+    end
+
+    vals2, vecs2, = eigsolve(A, 4, :LM; ishermitian=true)
+    @test vals ≈ vals2
+    for (v, v′) in zip(vecs, vecs2)
+        @test abs(inner(vcat(v...), v′)) ≈ 1
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,6 +46,10 @@ include("ad/svdsolve.jl")
 t = time() - t
 println("Tests finished in $t seconds")
 
+# Issues
+# ------
+include("issues.jl")
+
 module AquaTests
 using KrylovKit
 using Aqua


### PR DESCRIPTION
This is a more conservative approach to using the multithreaded kernels, which could even be reenabled by users by overloading the `_use_multithreaded_array_kernel`.

Fixes #100