### PR TITLE
Implement support for real linear maps

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -10,6 +10,7 @@ makedocs(; modules=[KrylovKit],
                              "man/eig.md",
                              "man/svd.md",
                              "man/matfun.md",
+                             "man/reallinear.md",
                              "man/algorithms.md",
                              "man/implementation.md"]],
          format=Documenter.HTML(; prettyurls=get(ENV, "CI", nothing) == "true"))

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -20,6 +20,11 @@ The high level interface of KrylovKit is provided by the following functions:
 *   [`expintegrator`](@ref): exponential integrator for a linear non-homogeneous ODE
     (generalization of `exponentiate`)
 
+Furthermore, for specialised use cases, there are functions that can deal with so-called
+"real linear maps", which arise e.g. in the context of differentiable programming:
+*   [`reallinsolve`](@ref) and [`realeigsolve`](@ref)
+
+
 ## Package features and alternatives
 This section could also be titled "Why did I create KrylovKit.jl"?
 

--- a/docs/src/man/eig.md
+++ b/docs/src/man/eig.md
@@ -41,11 +41,7 @@ corresponding to the largest magnitude eigenvalue of `A`.
 
 More generally, if you want to compute several eigenvalues of a real linear map, and you know
 that all of them are real, so that also the associated eigenvectors will be real, then you
-can use the `realeigsolve` method, which is also restricted to the 'expert' method call and
-which will error if any of the requested eigenvalues turn out to be complex
-```@docs
-realeigsolve
-```
+can use the [`realeigsolve`](@ref) method.
 
 ## Automatic differentation
 

--- a/docs/src/man/linear.md
+++ b/docs/src/man/linear.md
@@ -1,5 +1,7 @@
 # Linear problems
 
+## Linear systems
+
 Linear systems are of the form `A*x=b` where `A` should be a linear map that has the same
 type of output as input, i.e. the solution `x` should be of the same type as the right hand
 side `b`. They can be solved using the function `linsolve`:

--- a/docs/src/man/matfun.md
+++ b/docs/src/man/matfun.md
@@ -1,5 +1,5 @@
-# Functions of matrices and linear maps
-Applying a function of a matrix or linear map to a given vector can in some cases also be
+# Functions of matrices and linear operator
+Applying a function of a matrix or linear operator to a given vector can in some cases also be
 computed using Krylov methods. One example is the inverse function, which exactly
 corresponds to what `linsolve` computes: ``A^{-1} * b``. There are other functions ``f``
 for which ``f(A) * b`` can be computed using Krylov techniques, i.e. where ``f(A) * b`` can

--- a/docs/src/man/matfun.md
+++ b/docs/src/man/matfun.md
@@ -1,4 +1,4 @@
-# Functions of matrices and linear operator
+# Functions of matrices and linear operators
 Applying a function of a matrix or linear operator to a given vector can in some cases also be
 computed using Krylov methods. One example is the inverse function, which exactly
 corresponds to what `linsolve` computes: ``A^{-1} * b``. There are other functions ``f``

--- a/docs/src/man/reallinear.md
+++ b/docs/src/man/reallinear.md
@@ -1,0 +1,46 @@
+# Real linear maps
+
+A map $$f: V \to V$$ from some vector space $$V$$ to itself is said to be real linear map if
+it satisfies $$f(\alpha x + \beta y) = \alpha f(x) + \beta f(y)$$ for all $$x, y \in V$$ and
+all $$\alpha, \beta \in \mathbb{R}$$. When $$V$$ is itself a real vector space, this is just
+the natural concept of a linear map. However, this definition can be used even if $$x$$ and
+$$y$$ are naturally represented using complex numbers and arithmetic and also admit complex linear
+combinations, i.e. if $$V$$ is a complex vector space.
+
+Such real linear maps arise whenever `f(x)` involves calling `conj(x)`, and are for example
+obtained in the context of Jacobians (pullbacks) of complex valued functions that are not
+holomorphic.
+
+To deal with real linear maps, one should reinterpret $$V$$ as a real vector space, by
+restricting the possible linear combinations to those with real scalar coefficients, and by
+using the real part of the inner product. When the vectors are explictly represented as
+some `AbstractVector{Complex{T}}`, this could be obtained by explicitly splitting
+them in their real and imaginary parts and stacking those into `AbstractVector{T}` objects
+with twice the original length.
+
+However, KrylovKit.jl admits a different approach, where the original representation of
+vectors is kept, and the inner product is simply replaced by its real part. KrylovKit.jl
+offers specific methods for solving linear systems and eigenvalue systems in this way. For
+linear problems, this is implemented using `reallinsolve`:
+
+```@docs
+reallinsolve
+```
+
+In the case of eigenvalue systems, a similar method `realeigsolve` is available. In this
+context, only real eigenvalues are meaningful, as the corresponding eigenvectors should be
+built from real linear combinations of the vectors that span the (real) Krylov subspace.
+This approach can also be applied to linear maps on vectors that were naturally real to
+begin with, if it is guaranteed that the targetted eigenvalues are real. In that case, also
+the associated eigenvectors will be returned using only real arithmic. This is contrast
+with `eigsolve`, which will always turn to complex arithmetic if the linear map is real but
+not symmetric. An error will be thrown if complex eigenvalues are encountered within the
+targetted set.
+
+```@docs
+realeigsolve
+```
+
+Note that both `reallinsolve` and `realeigsolve` currently only exist with the "expert" mode
+interface, where the user has to manually specify the underlying Krylov algorithm and its
+parameters, i.e. `GMRES` or `BiCGStab` for `reallinsolve` and `Arnoldi` for `realeigsolve`.

--- a/docs/src/man/reallinear.md
+++ b/docs/src/man/reallinear.md
@@ -1,6 +1,6 @@
 # Real linear maps
 
-A map $$f: V \to V$$ from some vector space $$V$$ to itself is said to be real linear map if
+A map $$f: V \to V$$ from some vector space $$V$$ to itself is said to be a real linear map if
 it satisfies $$f(\alpha x + \beta y) = \alpha f(x) + \beta f(y)$$ for all $$x, y \in V$$ and
 all $$\alpha, \beta \in \mathbb{R}$$. When $$V$$ is itself a real vector space, this is just
 the natural concept of a linear map. However, this definition can be used even if $$x$$ and

--- a/docs/src/man/svd.md
+++ b/docs/src/man/svd.md
@@ -1,4 +1,6 @@
 # Singular value problems
+
+## Singular values and singular vectors
 It is possible to iteratively compute a few singular values and corresponding left and
 right singular vectors using the function `svdsolve`:
 

--- a/src/KrylovKit.jl
+++ b/src/KrylovKit.jl
@@ -221,13 +221,15 @@ function Base.show(io::IO, info::ConvergenceInfo)
     return println(io, "norms of residuals are given by $((info.normres...,)).")
 end
 
-# eigsolve en schursolve
-include("eigsolve/eigsolve.jl")
-include("eigsolve/lanczos.jl")
-include("eigsolve/arnoldi.jl")
-include("eigsolve/geneigsolve.jl")
-include("eigsolve/golubye.jl")
-include("eigsolve/svdsolve.jl")
+# vectors with modified inner product
+include("innerproductvec.jl")
+
+# support for real
+_realinner(v, w) = real(inner(v, w))
+const RealVec{V} = InnerProductVec{typeof(_realinner),V}
+RealVec(v) = InnerProductVec(v, realinner)
+
+apply(A, x::RealVec) = RealVec(apply(A, x[]))
 
 # linsolve
 include("linsolve/linsolve.jl")
@@ -235,12 +237,17 @@ include("linsolve/cg.jl")
 include("linsolve/gmres.jl")
 include("linsolve/bicgstab.jl")
 
+# eigsolve and svdsolve
+include("eigsolve/eigsolve.jl")
+include("eigsolve/lanczos.jl")
+include("eigsolve/arnoldi.jl")
+include("eigsolve/geneigsolve.jl")
+include("eigsolve/golubye.jl")
+include("eigsolve/svdsolve.jl")
+
 # exponentiate
 include("matrixfun/exponentiate.jl")
 include("matrixfun/expintegrator.jl")
-
-# custom vector types
-include("innerproductvec.jl")
 
 # deprecations
 include("deprecated.jl")

--- a/src/KrylovKit.jl
+++ b/src/KrylovKit.jl
@@ -29,7 +29,8 @@ using GPUArraysCore
 using PackageExtensionCompat
 const IndexRange = AbstractRange{Int}
 
-export linsolve, eigsolve, geneigsolve, realeigsolve, schursolve, svdsolve
+export linsolve, reallinsolve
+export eigsolve, geneigsolve, realeigsolve, schursolve, svdsolve
 export exponentiate, expintegrator
 export orthogonalize, orthogonalize!!, orthonormalize, orthonormalize!!
 export basis, rayleighquotient, residual, normres, rayleighextension

--- a/src/KrylovKit.jl
+++ b/src/KrylovKit.jl
@@ -227,7 +227,7 @@ include("innerproductvec.jl")
 # support for real
 _realinner(v, w) = real(inner(v, w))
 const RealVec{V} = InnerProductVec{typeof(_realinner),V}
-RealVec(v) = InnerProductVec(v, realinner)
+RealVec(v) = InnerProductVec(v, _realinner)
 
 apply(A, x::RealVec) = RealVec(apply(A, x[]))
 

--- a/src/eigsolve/arnoldi.jl
+++ b/src/eigsolve/arnoldi.jl
@@ -286,10 +286,8 @@ The return value is always of the form `vals, vecs, info = eigsolve(...)` with
     if `info.converged >= howmany`.
 """
 function realeigsolve(A, x₀, howmany::Int, which::Selector, alg::Arnoldi; alg_rrule=alg)
-    realinner = real ∘ inner
-    v₀ = InnerProductVec(x₀, realinner)
-    realA = v -> InnerProductVec(apply(A, v[]), realinner)
-    T, U, fact, converged, numiter, numops = _schursolve(realA, v₀, howmany, which, alg)
+    T, U, fact, converged, numiter, numops = _schursolve(A, RealVec(x₀), howmany, which,
+                                                         alg)
     i = 0
     while i < length(fact)
         i += 1

--- a/src/eigsolve/arnoldi.jl
+++ b/src/eigsolve/arnoldi.jl
@@ -185,9 +185,27 @@ end
     realeigsolve(f, x₀, howmany, which, algorithm; alg_rrule=algorithm)
 
 Compute the first `howmany` eigenvalues (according to the order specified by `which`)
-from the real linear map encoded in the matrix `A` or by the function `f`, with the guarantee
-that these eigenvalues (and thus their associated eigenvectors) are real.
+from the real linear map encoded in the matrix `A` or by the function `f`, if it can be
+guaranteed that these eigenvalues (and thus their associated eigenvectors) are real. An
+error will be thrown if there are complex eigenvalues within the first `howmany` eigenvalues.
+
 Return eigenvalues, eigenvectors and a `ConvergenceInfo` structure.
+
+!!! note "Note about real linear maps"
+
+    A function `f` is said to implement a real linear map if it satisfies 
+    `f(add(x,y)) = add(f(x), f(y)` and `f(scale(x, α)) = scale(f(x), α)` for vectors `x`
+    and `y` and scalars `α::Real`. Note that this is possible even when the vectors are
+    represented using complex arithmetic. For example, the map `f=x-> x + conj(x)`
+    represents a real linear map that is not (complex) linear, as it does not satisfy
+    `f(scale(x, α)) = scale(f(x), α)` for complex scalars `α`. Note that complex linear
+    maps are always real linear maps and thus can be used in this context, if looking
+    specifically for real eigenvalues that they may have.
+
+    To interpret the vectors `x` and `y` as elements from a real vector space, the standard
+    inner product defined on them will be replaced with `real(inner(x,y))`. This has no
+    effect if the vectors `x` and `y` were represented using real arithmetic to begin with,
+    and allows to seemlessly use complex vectors as well.
 
 ### Arguments:
 
@@ -268,33 +286,30 @@ The return value is always of the form `vals, vecs, info = eigsolve(...)` with
     if `info.converged >= howmany`.
 """
 function realeigsolve(A, x₀, howmany::Int, which::Selector, alg::Arnoldi; alg_rrule=alg)
-    T, U, fact, converged, numiter, numops = _schursolve(A, x₀, howmany, which, alg)
-    if !(eltype(T) <: Real)
-        throw(ArgumentError("realeigsolve can only be used for real eigenvalue problems"))
-    else
-        allreal = true
-        for i in 1:(howmany < length(fact) ? howmany : howmany - 1)
-            if T[i + 1, i] != 0
-                allreal = false
-                break
-            end
-        end
-        allreal || throw(ArgumentError("not all first `howmany` eigenvalues are real"))
-    end
-    if converged > howmany
-        while howmany < converged && T[howmany + 1, howmany] == 0
-            howmany += 1
+    realinner = real ∘ inner
+    v₀ = InnerProductVec(x₀, realinner)
+    realA = v -> InnerProductVec(apply(A, v[]), realinner)
+    T, U, fact, converged, numiter, numops = _schursolve(realA, v₀, howmany, which, alg)
+    i = 0
+    while i < length(fact)
+        i += 1
+        if i < length(fact) && T[i + 1, i] != 0
+            i -= 1
+            break
         end
     end
+    i < howmany &&
+        throw(ArgumentError("only the first $i eigenvalues are real, which is less then the requested `howmany = $howmany`"))
+    howmany = max(howmany, min(i, converged))
     TT = view(T, 1:howmany, 1:howmany)
     values = diag(TT)
 
     # Compute eigenvectors
     V = view(U, :, 1:howmany) * schur2realeigvecs(TT)
     vectors = let B = basis(fact)
-        [B * v for v in cols(V)]
+        [(B * v)[] for v in cols(V)]
     end
-    residuals = let r = residual(fact)
+    residuals = let r = residual(fact)[]
         [scale(r, last(v)) for v in cols(V)]
     end
     normresiduals = [normres(fact) * abs(last(v)) for v in cols(V)]

--- a/src/factorizations/arnoldi.jl
+++ b/src/factorizations/arnoldi.jl
@@ -140,8 +140,9 @@ function initialize(iter::ArnoldiIterator; verbosity::Int=0)
     iszero(β₀) && throw(ArgumentError("initial vector should not have norm zero"))
     Ax₀ = apply(iter.operator, x₀)
     α = inner(x₀, Ax₀) / (β₀ * β₀)
-    T = typeof(α)
+    T = typeof(α) # scalar type of the Rayleigh quotient
     # this line determines the vector type that we will henceforth use
+    # vector scalar type can be different from `T`, e.g. for real inner products
     v = add!!(scale(Ax₀, zero(α)), x₀, 1 / β₀)
     if typeof(Ax₀) != typeof(v)
         r = add!!(zerovector(v), Ax₀, 1 / β₀)

--- a/src/factorizations/arnoldi.jl
+++ b/src/factorizations/arnoldi.jl
@@ -142,7 +142,7 @@ function initialize(iter::ArnoldiIterator; verbosity::Int=0)
     α = inner(x₀, Ax₀) / (β₀ * β₀)
     T = typeof(α)
     # this line determines the vector type that we will henceforth use
-    v = add!!(zerovector(Ax₀, T), x₀, 1 / β₀)
+    v = add!!(scale(Ax₀, zero(α)), x₀, 1 / β₀)
     if typeof(Ax₀) != typeof(v)
         r = add!!(zerovector(v), Ax₀, 1 / β₀)
     else

--- a/src/factorizations/gkl.jl
+++ b/src/factorizations/gkl.jl
@@ -193,10 +193,10 @@ function initialize(iter::GKLIterator; verbosity::Int=0)
     Av₀ = apply_normal(iter.operator, v₀) # apply operator
     α² = inner(u₀, Av₀) / β₀^2
     α² ≈ α * α || throw(ArgumentError("operator and its adjoint are not compatible"))
-    T = typeof(α²)
-    # these lines determines the type that we will henceforth use
+    T = typeof(α²) # scalar type of the Rayleigh quotient
 
-    u = scale!!(zerovector(u₀, T), u₀, 1 / β₀) # (one(T) / β₀) * u₀
+    # these lines determines the vector types that we will henceforth use
+    u = scale(u₀, one(T) / β₀)
     v = scale(v₀, one(T) / (α * β₀))
     if typeof(Av₀) == typeof(u)
         r = scale!!(Av₀, 1 / (α * β₀))

--- a/src/factorizations/lanczos.jl
+++ b/src/factorizations/lanczos.jl
@@ -179,9 +179,10 @@ function initialize(iter::LanczosIterator; verbosity::Int=0)
     iszero(β₀) && throw(ArgumentError("initial vector should not have norm zero"))
     Ax₀ = apply(iter.operator, x₀)
     α = inner(x₀, Ax₀) / (β₀ * β₀)
-    T = typeof(α)
+    T = typeof(α) # scalar type of the Rayleigh quotient
     # this line determines the vector type that we will henceforth use
-    v = add!!(zerovector(Ax₀, T), x₀, 1 / β₀)
+    # vector scalar type can be different from `T`, e.g. for real inner products
+    v = add!!(scale(Ax₀, zero(α)), x₀, 1 / β₀)
     if typeof(Ax₀) != typeof(v)
         r = add!!(zerovector(v), Ax₀, 1 / β₀)
     else

--- a/src/innerproductvec.jl
+++ b/src/innerproductvec.jl
@@ -89,10 +89,16 @@ end
 function VectorInterface.scale(v::InnerProductVec, a::Number)
     return InnerProductVec(scale(v.vec, a), v.dotf)
 end
-
+function VectorInterface.scale!!(v::InnerProductVec, a::Number)
+    return InnerProductVec(scale!!(v.vec, a), v.dotf)
+end
 function VectorInterface.scale!(v::InnerProductVec, a::Number)
     scale!(v.vec, a)
     return v
+end
+function VectorInterface.scale!!(w::InnerProductVec{F}, v::InnerProductVec{F},
+                                 a::Number) where {F}
+    return InnerProductVec(scale!!(w.vec, v.vec, a), w.dotf)
 end
 function VectorInterface.scale!(w::InnerProductVec{F}, v::InnerProductVec{F},
                                 a::Number) where {F}
@@ -100,6 +106,14 @@ function VectorInterface.scale!(w::InnerProductVec{F}, v::InnerProductVec{F},
     return w
 end
 
+function VectorInterface.add(v::InnerProductVec{F}, w::InnerProductVec{F}, a::Number,
+                             b::Number) where {F}
+    return InnerProductVec(add(v.vec, w.vec, a, b), v.dotf)
+end
+function VectorInterface.add!!(v::InnerProductVec{F}, w::InnerProductVec{F}, a::Number,
+                               b::Number) where {F}
+    return InnerProductVec(add!!(v.vec, w.vec, a, b), v.dotf)
+end
 function VectorInterface.add!(v::InnerProductVec{F}, w::InnerProductVec{F}, a::Number,
                               b::Number) where {F}
     add!(v.vec, w.vec, a, b)

--- a/src/linsolve/linsolve.jl
+++ b/src/linsolve/linsolve.jl
@@ -243,10 +243,7 @@ used, and therefore no restarts are required. Therefore, we pass `krylovdim*maxi
 maximal number of CG iterations that can be used by the `CG` algorithm.
 """
 function reallinsolve(f, b, x₀, alg, a₀::Real=0, a₁::Real=1)
-    v₀ = InnerProductVec(x₀, real ∘ inner)
-    w = InnerProductVec(b, real ∘ inner)
-    realf(v) = InnerProductVec(apply(f, v[]), real ∘ inner)
-    x, info = linsolve(realf, w, v₀, alg, a₀, a₁)
+    x, info = linsolve(f, RealVec(b), RealVec(x₀), alg, a₀, a₁)
 
     newinfo = ConvergenceInfo(info.converged, info.residual[], info.normres, info.numiter,
                               info.numops)

--- a/src/linsolve/linsolve.jl
+++ b/src/linsolve/linsolve.jl
@@ -22,7 +22,7 @@ type `x` and `b`.
 The return value is always of the form `x, info = linsolve(...)` with
 
   - `x`: the approximate solution to the problem, similar type as the right hand side `b`
-    but possibly with a different `eltype`
+    but possibly with a different `scalartype`
 
   - `info`: an object of type [`ConvergenceInfo`], which has the following fields
 
@@ -174,11 +174,78 @@ function linselector(A::AbstractMatrix,
                  verbosity=verbosity)
 end
 
+"""
+    reallinsolve(f, b, x₀, algorithm, [a₀::Real = 0, a₁::Real = 1]; alg_rrule=algorithm)
+
+Compute a solution `x` to the linear system `a₀ * x + a₁ * f(x) = b`, using a starting guess
+`x₀`, where `f` represents a real linear map.
+Return the approximate solution `x` and a `ConvergenceInfo` structure.
+
+!!! note "Note about real linear maps"
+
+    A function `f` is said to implement a real linear map if it satisfies 
+    `f(add(x,y)) = add(f(x), f(y)` and `f(scale(x, α)) = scale(f(x), α)` for vectors `x`
+    and `y` and scalars `α::Real`. Note that this is possible even when the vectors are
+    represented using complex arithmetic. For example, the map `f=x-> x + conj(x)`
+    represents a real linear map that is not (complex) linear, as it does not satisfy
+    `f(scale(x, α)) = scale(f(x), α)` for complex scalars `α`. Note that complex linear
+    maps are always real linear maps and thus can be used in this context, though in that
+    case `linsolve` and `reallinsolve` target the same solution. However, they still compute
+    that solution using different arithmetic, and in that case `linsolve` might be more
+    efficient.
+
+    To interpret the vectors `x` and `y` as elements from a real vector space, the standard
+    inner product defined on them will be replaced with `real(inner(x,y))`. This has no
+    effect if the vectors `x` and `y` were represented using real arithmetic to begin with,
+    and allows to seemlessly use complex vectors as well.
+
+
+### Arguments:
+
+The linear map can be an `AbstractMatrix` (dense or sparse) or a general function or
+callable object. The real numbers `a₀` and `a₁` are optional arguments; they are applied 
+implicitly,  i.e. they do not contribute the computation time of applying the linear map or
+to the  number of operations on vectors of type `x` and `b`.
+
+### Return values:
+
+The return value is always of the form `x, info = linsolve(...)` with
+
+  - `x`: the approximate solution to the problem, similar type as the right hand side `b`
+    but possibly with a different `scalartype`
+
+  - `info`: an object of type [`ConvergenceInfo`], which has the following fields
+
+      + `info.converged::Int`: takes value 0 or 1 depending on whether the solution was
+        converged up to the requested tolerance
+      + `info.residual`: residual `b - f(x)` of the approximate solution `x`
+      + `info.normres::Real`: norm of the residual, i.e. `norm(info.residual)`
+      + `info.numops::Int`: total number of times that the linear map was applied, i.e. the
+        number of times that `f` was called, or a vector was multiplied with `A`
+      + `info.numiter::Int`: number of times the Krylov subspace was restarted (see below)
+
+!!! warning "Check for convergence"
+
+    No warning is printed if no converged solution was found, so always check if
+    `info.converged == 1`.
+
+
+### Algorithms
+
+The final (expert) method, without default values and keyword arguments, is the one that is
+finally called, and can also be used directly. Here, one specifies the algorithm explicitly.
+Currently, only [`CG`](@ref), [`GMRES`](@ref) and [`BiCGStab`](@ref) are implemented, where
+`CG` is chosen if `isposdef == true` and `GMRES` is chosen otherwise. Note that in standard
+`GMRES` terminology, our parameter `krylovdim` is referred to as the *restart* parameter,
+and our `maxiter` parameter counts the number of outer iterations, i.e. restart cycles. In
+`CG`, the Krylov subspace is only implicit because short recurrence relations are being
+used, and therefore no restarts are required. Therefore, we pass `krylovdim*maxiter` as the
+maximal number of CG iterations that can be used by the `CG` algorithm.
+"""
 function reallinsolve(f, b, x₀, alg, a₀::Real=0, a₁::Real=1)
-    realinner = real ∘ inner
-    v₀ = InnerProductVec(x₀, realinner)
-    w = InnerProductVec(b, realinner)
-    realf = v -> InnerProductVec(apply(f, v[]), realinner)
+    v₀ = InnerProductVec(x₀, real ∘ inner)
+    w = InnerProductVec(b, real ∘ inner)
+    realf(v) = InnerProductVec(apply(f, v[]), real ∘ inner)
     x, info = linsolve(realf, w, v₀, alg, a₀, a₁)
 
     newinfo = ConvergenceInfo(info.converged, info.residual[], info.normres, info.numiter,

--- a/src/linsolve/linsolve.jl
+++ b/src/linsolve/linsolve.jl
@@ -173,3 +173,15 @@ function linselector(A::AbstractMatrix,
                  orth=orth,
                  verbosity=verbosity)
 end
+
+function reallinsolve(f, b, x₀, alg, a₀::Real=0, a₁::Real=1)
+    realinner = real ∘ inner
+    v₀ = InnerProductVec(x₀, realinner)
+    w = InnerProductVec(b, realinner)
+    realf = v -> InnerProductVec(apply(f, v[]), realinner)
+    x, info = linsolve(realf, w, v₀, alg, a₀, a₁)
+
+    newinfo = ConvergenceInfo(info.converged, info.residual[], info.normres, info.numiter,
+                              info.numops)
+    return x[], newinfo
+end

--- a/test/linsolve.jl
+++ b/test/linsolve.jl
@@ -63,19 +63,35 @@ end
         x, info = @constinferred linsolve(wrapop(A, Val(mode)), wrapvec(b, Val(mode));
                                           krylovdim=n, maxiter=2,
                                           rtol=tolerance(T), verbosity=1)
-        @test info.converged > 0
+        @test info.converged == 1
         @test unwrapvec(b) ≈ A * unwrapvec(x)
-        x, info = @constinferred linsolve(wrapop(A, Val(mode)), wrapvec(b, Val(mode)), x;
-                                          krylovdim=n, maxiter=2,
-                                          rtol=tolerance(T))
+        x, info = @constinferred linsolve(wrapop(A, Val(mode)), wrapvec(b, Val(mode)), x,
+                                          alg)
         @test info.numops == 1
+
+        nreal = (T <: Real) ? n : 2n
+        algr = GMRES(; krylovdim=nreal, maxiter=2, tol=tolerance(T) * norm(b), verbosity=2)
+        xr, infor = @constinferred reallinsolve(wrapop(A, Val(mode)), wrapvec(b, Val(mode)),
+                                                zerovector(x), algr)
+        @test infor.converged == 1
+        @test unwrapvec(x) ≈ unwrapvec(xr)
 
         A = rand(T, (n, n))
         α₀ = rand(T)
         α₁ = -rand(T)
         x, info = @constinferred(linsolve(A, b, zerovector(b), alg, α₀, α₁))
         @test unwrapvec(b) ≈ (α₀ * I + α₁ * A) * unwrapvec(x)
-        @test info.converged > 0
+        @test info.converged == 1
+
+        if mode == :vector && T <: Complex
+            B = rand(T, (n, n))
+            f = buildrealmap(A, B)
+            α₀ = rand(real(T))
+            α₁ = -rand(real(T))
+            xr, infor = @constinferred reallinsolve(f, b, zerovector(b), algr, α₀, α₁)
+            @test infor.converged == 1
+            @test b ≈ (α₀ * xr + α₁ * A * xr + α₁ * B * conj(xr))
+        end
     end
 end
 
@@ -92,14 +108,28 @@ end
                                           maxiter=50, rtol=tolerance(T))
         @test unwrapvec(b) ≈ A * unwrapvec(x) + unwrapvec(info.residual)
 
+        alg = GMRES(; krylovdim=3 * n, maxiter=50, tol=tolerance(T) * norm(b), verbosity=2)
+        xr, infor = @constinferred reallinsolve(wrapop(A, Val(mode)), wrapvec(b, Val(mode)),
+                                                zerovector(x), alg)
+        @test unwrapvec(b) ≈ A * unwrapvec(xr) + unwrapvec(infor.residual)
+
         A = rand(T, (N, N)) .- one(T) / 2
         α₀ = maximum(abs, eigvals(A))
-        α₁ = -rand(T)
-        α₁ *= T(9) / T(10) / abs(α₁)
+        α₁ = -9 * rand(T) / 10
         x, info = @constinferred linsolve(wrapop(A, Val(mode)), wrapvec(b, Val(mode)), α₀,
                                           α₁; krylovdim=3 * n,
                                           maxiter=50, rtol=tolerance(T))
         @test unwrapvec(b) ≈ (α₀ * I + α₁ * A) * unwrapvec(x) + unwrapvec(info.residual)
+
+        if mode == :vector && T <: Complex
+            A = rand(T, (N, N)) .- one(T) / 2
+            B = rand(T, (N, N)) .- one(T) / 2
+            f = buildrealmap(A, B)
+            α₀ = 1
+            α₁ = -1 / (maximum(abs, eigvals(A)) + maximum(abs, eigvals(B)))
+            xr, infor = @constinferred reallinsolve(f, b, zerovector(b), alg, α₀, α₁)
+            @test b ≈ (α₀ * xr + α₁ * A * xr + α₁ * B * conj(xr)) + infor.residual
+        end
     end
 end
 
@@ -123,8 +153,7 @@ end
         A = rand(T, (N, N)) .- one(T) / 2
         b = rand(T, N)
         α₀ = maximum(abs, eigvals(A))
-        α₁ = -rand(T)
-        α₁ *= T(9) / T(10) / abs(α₁)
+        α₁ = -9 * rand(real(T)) / 10
         alg = BiCGStab(; maxiter=2, tol=tolerance(T) * norm(b), verbosity=1)
         x, info = @constinferred linsolve(wrapop(A, Val(mode)), wrapvec(b, Val(mode)),
                                           wrapvec(zerovector(b), Val(mode)), alg, α₀,
@@ -135,5 +164,21 @@ end
                                           alg, α₀, α₁)
         @test info.converged > 0
         @test unwrapvec(b) ≈ (α₀ * I + α₁ * A) * unwrapvec(x)
+
+        xr, infor = @constinferred reallinsolve(wrapop(A, Val(mode)), wrapvec(b, Val(mode)),
+                                                zerovector(x), alg, α₀, α₁)
+        @test infor.converged > 0
+        @test unwrapvec(xr) ≈ unwrapvec(x)
+
+        if mode == :vector && T <: Complex
+            A = rand(T, (N, N)) .- one(T) / 2
+            B = rand(T, (N, N)) .- one(T) / 2
+            f = buildrealmap(A, B)
+            α₀ = 1
+            α₁ = -1 / (maximum(abs, eigvals(A)) + maximum(abs, eigvals(B)))
+            xr, infor = @constinferred reallinsolve(f, b, zerovector(b), alg, α₀, α₁)
+            @test info.converged > 0
+            @test b ≈ (α₀ * xr + α₁ * A * xr + α₁ * B * conj(xr))
+        end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,8 +25,8 @@ const mgsr = ModifiedGramSchmidtIR(η₀)
 # Tests
 # -----
 t = time()
-# include("factorize.jl")
-# include("gklfactorize.jl")
+include("factorize.jl")
+include("gklfactorize.jl")
 
 include("linsolve.jl")
 include("eigsolve.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,8 +25,8 @@ const mgsr = ModifiedGramSchmidtIR(η₀)
 # Tests
 # -----
 t = time()
-include("factorize.jl")
-include("gklfactorize.jl")
+# include("factorize.jl")
+# include("gklfactorize.jl")
 
 include("linsolve.jl")
 include("eigsolve.jl")

--- a/test/testsetup.jl
+++ b/test/testsetup.jl
@@ -1,7 +1,7 @@
 module TestSetup
 
 export tolerance, ≊, MinimalVec, isinplace, stack
-export wrapop, wrapvec, unwrapvec
+export wrapop, wrapvec, unwrapvec, buildrealmap
 
 import VectorInterface as VI
 using VectorInterface
@@ -24,6 +24,10 @@ function ≊(list1::AbstractVector, list2::AbstractVector)
         ind2 = deleteat!(ind2, j)
     end
     return list1 ≈ view(list2, p)
+end
+
+function buildrealmap(A, B)
+    return x -> A * x + B * conj(x)
 end
 
 # Minimal vector type

--- a/test/testsetup.jl
+++ b/test/testsetup.jl
@@ -133,6 +133,7 @@ end
 
 if VERSION < v"1.9"
     stack(f, itr) = mapreduce(f, hcat, itr)
+    stack(itr) = reduce(hcat, itr)
 end
 
 end


### PR DESCRIPTION
This PR refactors the existing `realeigsolve`, and similarly implements a `reallinsolve`, to deal with so called `real linear maps`, i.e. maps that are additive f(x+y) = f(x)+f(y) and homogeneous f(a * x) = a * f(x), but only with respect to real scalars a. It can happen that x and y are nonetheless complex vectors, but f(x) is only real linear because it for example depends on `conj(x)`. Indeed, any real linear map can be represented as `f(x) = A * x + B * conj(x)` where `A` and `B` are complex matrices, but we want to work with an implicit representation of course.

The only change necessary to consider `x` and `y` as elements of a real vector space (with a real dimension that is twice as large as the original complex dimension) is to replace their complex inner product with its real part. Then, we can use the standard algorithms. For `realeigsolve`, we of course can only have real eigenvalues with corresponding eigenvectors, as complex linear combinations are not allowed (and would in fact yield wrong results).

TODO: tests