### PR TITLE
More verbosity (and other) fixes for v9

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "KrylovKit"
 uuid = "0b1a1467-8014-51b9-945f-bf0ae24f4b77"
 authors = ["Jutho Haegeman"]
-version = "0.9.2"
+version = "0.9.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/eigsolve/arnoldi.jl
+++ b/src/eigsolve/arnoldi.jl
@@ -342,7 +342,7 @@ function _schursolve(A, x₀, howmany::Int, which::Selector, alg::Arnoldi)
     numiter = 1
     # initialize arnoldi factorization
     iter = ArnoldiIterator(A, x₀, alg.orth)
-    fact = initialize(iter; verbosity=alg.verbosity - EACHITERATION_LEVEL)
+    fact = initialize(iter; verbosity=alg.verbosity)
     numops = 1
     sizehint!(fact, krylovdim)
     β = normres(fact)
@@ -398,7 +398,7 @@ function _schursolve(A, x₀, howmany::Int, which::Selector, alg::Arnoldi)
         end
 
         if K < krylovdim # expand
-            fact = expand!(iter, fact; verbosity=alg.verbosity - EACHITERATION_LEVEL)
+            fact = expand!(iter, fact; verbosity=alg.verbosity)
             numops += 1
         else # shrink
             numiter == maxiter && break
@@ -430,7 +430,7 @@ function _schursolve(A, x₀, howmany::Int, which::Selector, alg::Arnoldi)
             B[keep + 1] = scale!!(r, 1 / normres(fact))
 
             # Shrink Arnoldi factorization
-            fact = shrink!(fact, keep; verbosity=alg.verbosity - EACHITERATION_LEVEL)
+            fact = shrink!(fact, keep; verbosity=alg.verbosity)
             numiter += 1
         end
     end

--- a/src/eigsolve/golubye.jl
+++ b/src/eigsolve/golubye.jl
@@ -105,7 +105,7 @@ function geneigsolve(f, x₀, howmany::Int, which::Selector, alg::GolubYe)
             resize!(normresiduals, 0)
             while converged < K
                 z = view(Z, :, p[converged + 1])
-                v = mul!(zerovector(vold), V, z)
+                v = unproject!!(zerovector(vold), V, z)
                 av, bv = genapply(f, v)
                 numops += 1
                 ρ = checkhermitian(inner(v, av)) / checkposdef(inner(v, bv))
@@ -129,7 +129,7 @@ function geneigsolve(f, x₀, howmany::Int, which::Selector, alg::GolubYe)
             elseif numiter == maxiter
                 for k in (converged + 1):howmany
                     z = view(Z, :, p[k])
-                    v = mul!(zerovector(vold), V, z)
+                    v = unproject!!(zerovector(vold), V, z)
                     av, bv = genapply(f, v)
                     numops += 1
                     ρ = checkhermitian(inner(v, av)) / checkposdef(inner(v, bv))

--- a/src/eigsolve/lanczos.jl
+++ b/src/eigsolve/lanczos.jl
@@ -13,7 +13,7 @@ function eigsolve(A, x₀, howmany::Int, which::Selector, alg::Lanczos;
 
     # Initialize Lanczos factorization
     iter = LanczosIterator(A, x₀, alg.orth)
-    fact = initialize(iter; verbosity=alg.verbosity - EACHITERATION_LEVEL)
+    fact = initialize(iter; verbosity=alg.verbosity)
     numops = 1
     numiter = 1
     sizehint!(fact, krylovdim)
@@ -72,7 +72,7 @@ function eigsolve(A, x₀, howmany::Int, which::Selector, alg::Lanczos;
         end
 
         if K < krylovdim # expand Krylov factorization
-            fact = expand!(iter, fact; verbosity=alg.verbosity - EACHITERATION_LEVEL)
+            fact = expand!(iter, fact; verbosity=alg.verbosity)
             numops += 1
         else ## shrink and restart
             if numiter == maxiter
@@ -108,7 +108,7 @@ function eigsolve(A, x₀, howmany::Int, which::Selector, alg::Lanczos;
             B[keep + 1] = scale!!(r, 1 / β)
 
             # Shrink Lanczos factorization
-            fact = shrink!(fact, keep; verbosity=alg.verbosity - EACHITERATION_LEVEL)
+            fact = shrink!(fact, keep; verbosity=alg.verbosity)
             numiter += 1
         end
     end

--- a/src/eigsolve/svdsolve.jl
+++ b/src/eigsolve/svdsolve.jl
@@ -157,7 +157,7 @@ function svdsolve(A, x₀, howmany::Int, which::Symbol, alg::GKL;
     numiter = 1
     # initialize GKL factorization
     iter = GKLIterator(A, x₀, alg.orth)
-    fact = initialize(iter; verbosity=alg.verbosity - EACHITERATION_LEVEL)
+    fact = initialize(iter; verbosity=alg.verbosity)
     numops = 2
     sizehint!(fact, krylovdim)
     β = normres(fact)
@@ -214,7 +214,7 @@ function svdsolve(A, x₀, howmany::Int, which::Symbol, alg::GKL;
         end
 
         if K < krylovdim # expand
-            fact = expand!(iter, fact; verbosity=alg.verbosity - EACHITERATION_LEVEL)
+            fact = expand!(iter, fact; verbosity=alg.verbosity)
             numops += 2
         else ## shrink and restart
             if numiter == maxiter
@@ -267,7 +267,7 @@ function svdsolve(A, x₀, howmany::Int, which::Symbol, alg::GKL;
                 fact.βs[j] = H[j + 1, j]
             end
             # Shrink GKL factorization
-            fact = shrink!(fact, keep; verbosity=alg.verbosity - EACHITERATION_LEVEL)
+            fact = shrink!(fact, keep; verbosity=alg.verbosity)
             numiter += 1
         end
     end

--- a/src/factorizations/gkl.jl
+++ b/src/factorizations/gkl.jl
@@ -183,7 +183,7 @@ function Base.iterate(iter::GKLIterator, state::GKLFactorization)
     end
 end
 
-function initialize(iter::GKLIterator; verbosity::Int=0)
+function initialize(iter::GKLIterator; verbosity::Int=KrylovDefaults.verbosity[])
     # initialize without using eltype
     u₀ = iter.u₀
     β₀ = norm(u₀)
@@ -211,12 +211,13 @@ function initialize(iter::GKLIterator; verbosity::Int=0)
     S = real(T)
     αs = S[α]
     βs = S[β]
-    if verbosity > 0
+    if verbosity > EACHITERATION_LEVEL
         @info "GKL initiation at dimension 1: subspace normres = $(normres2string(β))"
     end
     return GKLFactorization(1, U, V, αs, βs, r)
 end
-function initialize!(iter::GKLIterator, state::GKLFactorization; verbosity::Int=0)
+function initialize!(iter::GKLIterator, state::GKLFactorization;
+                     verbosity::Int=KrylovDefaults.verbosity[])
     U = state.U
     while length(U) > 1
         pop!(U)
@@ -238,12 +239,13 @@ function initialize!(iter::GKLIterator, state::GKLFactorization; verbosity::Int=
     push!(αs, α)
     push!(βs, β)
     state.r = r
-    if verbosity > 0
+    if verbosity > EACHITERATION_LEVEL
         @info "GKL initiation at dimension 1: subspace normres = $(normres2string(β))"
     end
     return state
 end
-function expand!(iter::GKLIterator, state::GKLFactorization; verbosity::Int=0)
+function expand!(iter::GKLIterator, state::GKLFactorization;
+                 verbosity::Int=KrylovDefaults.verbosity[])
     βold = normres(state)
     U = state.U
     V = state.V
@@ -259,12 +261,12 @@ function expand!(iter::GKLIterator, state::GKLFactorization; verbosity::Int=0)
 
     state.k += 1
     state.r = r
-    if verbosity > 0
+    if verbosity > EACHITERATION_LEVEL
         @info "GKL expension to dimension $(state.k): subspace normres = $(normres2string(β))"
     end
     return state
 end
-function shrink!(state::GKLFactorization, k; verbosity::Int=0)
+function shrink!(state::GKLFactorization, k; verbosity::Int=KrylovDefaults.verbosity[])
     length(state) == length(state.V) ||
         error("we cannot shrink GKLFactorization without keeping vectors")
     length(state) <= k && return state
@@ -280,7 +282,7 @@ function shrink!(state::GKLFactorization, k; verbosity::Int=0)
     resize!(state.βs, k)
     state.k = k
     β = normres(state)
-    if verbosity > 0
+    if verbosity > EACHITERATION_LEVEL
         @info "GKL reduction to dimension $k: subspace normres = $(normres2string(β))"
     end
     state.r = scale!!(r, β)

--- a/src/linsolve/gmres.jl
+++ b/src/linsolve/gmres.jl
@@ -37,7 +37,7 @@ function linsolve(operator, b, x₀, alg::GMRES, a₀::Number=0, a₁::Number=1;
     numops = 1 # operator has been applied once to determine T and r
 
     iter = ArnoldiIterator(operator, r, alg.orth)
-    fact = initialize(iter)
+    fact = initialize(iter; verbosity=0)
     sizehint!(fact, alg.krylovdim)
     numops += 1 # start applies operator once
 
@@ -56,7 +56,7 @@ function linsolve(operator, b, x₀, alg::GMRES, a₀::Number=0, a₁::Number=1;
             if alg.verbosity >= EACHITERATION_LEVEL
                 @info "GMRES linsolve in iteration $numiter; step $k: normres = $(normres2string(β))"
             end
-            fact = expand!(iter, fact)
+            fact = expand!(iter, fact; verbosity=0)
             numops += 1 # expand! applies the operator once
             k = length(fact)
             H = rayleighquotient(fact)
@@ -132,6 +132,6 @@ function linsolve(operator, b, x₀, alg::GMRES, a₀::Number=0, a₁::Number=1;
 
         # Restart Arnoldi factorization with new r
         iter = ArnoldiIterator(operator, r, alg.orth)
-        fact = initialize!(iter, fact)
+        fact = initialize!(iter, fact; verbosity=0)
     end
 end

--- a/src/matrixfun/expintegrator.jl
+++ b/src/matrixfun/expintegrator.jl
@@ -172,7 +172,7 @@ function expintegrator(A, t::Number, u::Tuple, alg::Union{Lanczos,Arnoldi})
     else
         iter = ArnoldiIterator(A, w[p + 1], alg.orth)
     end
-    fact = initialize(iter; verbosity=alg.verbosity - 2)
+    fact = initialize(iter; verbosity=alg.verbosity)
     numops += 1
     sizehint!(fact, krylovdim)
 
@@ -283,7 +283,7 @@ function expintegrator(A, t::Number, u::Tuple, alg::Union{Lanczos,Arnoldi})
             end
         end
         if K < krylovdim
-            fact = expand!(iter, fact; verbosity=alg.verbosity - EACHITERATION_LEVEL)
+            fact = expand!(iter, fact; verbosity=alg.verbosity)
             numops += 1
         else
             for j in 1:p
@@ -314,7 +314,7 @@ function expintegrator(A, t::Number, u::Tuple, alg::Union{Lanczos,Arnoldi})
             else
                 iter = ArnoldiIterator(A, w[p + 1], alg.orth)
             end
-            fact = initialize!(iter, fact; verbosity=alg.verbosity - EACHITERATION_LEVEL)
+            fact = initialize!(iter, fact; verbosity=alg.verbosity)
             numops += 1
             numiter += 1
         end


### PR DESCRIPTION
Among other things, also only print the non-hermitian warning in the `LanczosIterator` if `verbosity >= WARN_LEVEL`.

Also deprecate `mul!` in favour of `unproject!!` to reflect the bangbang nature of this method.