### PR TITLE
add missing unthunk in fH definition

### DIFF
--- a/ext/KrylovKitChainRulesCoreExt/eigsolve.jl
+++ b/ext/KrylovKitChainRulesCoreExt/eigsolve.jl
@@ -18,7 +18,7 @@ function ChainRulesCore.rrule(config::RuleConfig,
         fᴴ = adjoint(f)
     else
         fᴴ = let pb = rrule_via_ad(config, f, zerovector(x₀, complex(scalartype(x₀))))[2]
-            v -> pb(v)[2]
+            v -> unthunk(pb(v)[2])
         end
     end
     eigsolve_pullback = make_eigsolve_pullback(config, f, fᴴ, x₀, howmany, which,

--- a/ext/KrylovKitChainRulesCoreExt/linsolve.jl
+++ b/ext/KrylovKitChainRulesCoreExt/linsolve.jl
@@ -53,7 +53,7 @@ function lin_preprocess(config, f, x)
         throw(ArgumentError("`linsolve` reverse-mode AD requires AD engine that supports calling back into AD"))
     pb = rrule_via_ad(config, f, x)[2]
     fᴴ, construct∂f_lin = let pb = rrule_via_ad(config, f, x)[2]
-        v -> pb(v)[2], w -> pb(w)[1]
+        v -> unthunk(pb(v)[2]), w -> pb(w)[1]
     end
     return fᴴ, construct∂f_lin
 end


### PR DESCRIPTION
This should fix #119 . I would like to add a test, but without using TensorKit. I couldn't find an easy linear function on `Vector` instances that introduces thunks. Suggestions are welcome.