### PR TITLE
Add Two-sided Arnoldi method

### DIFF
--- a/src/KrylovKit.jl
+++ b/src/KrylovKit.jl
@@ -36,8 +36,8 @@ export basis, rayleighquotient, residual, normres, rayleighextension
 export initialize, initialize!, expand!, shrink!
 export ClassicalGramSchmidt, ClassicalGramSchmidt2, ClassicalGramSchmidtIR
 export ModifiedGramSchmidt, ModifiedGramSchmidt2, ModifiedGramSchmidtIR
-export LanczosIterator, ArnoldiIterator, GKLIterator
-export CG, GMRES, BiCGStab, Lanczos, Arnoldi, GKL, GolubYe, LSMR
+export LanczosIterator, ArnoldiIterator, GKLIterator, BiArnoldiIterator
+export CG, GMRES, BiCGStab, Lanczos, Arnoldi, GKL, GolubYe, LSMR, BiArnoldi
 export KrylovDefaults, EigSorter
 export RecursiveVec, InnerProductVec
 
@@ -176,6 +176,7 @@ include("dense/reflector.jl")
 include("factorizations/krylov.jl")
 include("factorizations/lanczos.jl")
 include("factorizations/arnoldi.jl")
+include("factorizations/biarnoldi.jl")
 include("factorizations/gkl.jl")
 
 # A general structure to pass on convergence information
@@ -269,6 +270,7 @@ include("lssolve/lsmr.jl")
 include("eigsolve/eigsolve.jl")
 include("eigsolve/lanczos.jl")
 include("eigsolve/arnoldi.jl")
+include("eigsolve/biarnoldi.jl")
 include("eigsolve/geneigsolve.jl")
 include("eigsolve/golubye.jl")
 include("eigsolve/svdsolve.jl")

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -204,6 +204,24 @@ function Arnoldi(;
     return Arnoldi(orth, krylovdim, maxiter, tol, eager, verbosity)
 end
 
+struct BiArnoldi{O<:Orthogonalizer,S<:Real} <: KrylovAlgorithm
+    orth::O
+    krylovdim::Int
+    maxiter::Int
+    tol::S
+    eager::Bool
+    verbosity::Int
+end
+function BiArnoldi(;
+                 krylovdim::Int=KrylovDefaults.krylovdim[],
+                 maxiter::Int=KrylovDefaults.maxiter[],
+                 tol::Real=KrylovDefaults.tol[],
+                 orth::Orthogonalizer=KrylovDefaults.orth,
+                 eager::Bool=false,
+                 verbosity::Int=KrylovDefaults.verbosity[])
+    return BiArnoldi(orth, krylovdim, maxiter, tol, eager, verbosity)
+end
+
 """
     GolubYe(; krylovdim=KrylovDefaults.krylovdim[],
             maxiter=KrylovDefaults.maxiter[],

--- a/src/eigsolve/biarnoldi.jl
+++ b/src/eigsolve/biarnoldi.jl
@@ -123,8 +123,8 @@ function _schursolve(A, AH, v₀, w₀, howmany::Int, which::Selector, alg::BiAr
             # Step 2 and 3 - Correct H, K and the residuals using the oblique projection
 
             # Compute the projections W* residual(V) and V* residual(W)
-            Wv = zeros(krylovdim)
-            Vw = zeros(krylovdim)
+            Wv = zeros(eltype(rV), krylovdim)
+            Vw = zeros(eltype(rV), krylovdim)
             for i in eachindex(Wv)
                 Wv[i] = dot(fact.W[i], rV)
                 Vw[i] = dot(fact.V[i], rW)
@@ -200,8 +200,8 @@ function _schursolve(A, AH, v₀, w₀, howmany::Int, which::Selector, alg::BiAr
             Vv = -adjoint(Q[:, 1:keep]) * MWv
             Ww = -adjoint(Z[:, 1:keep]) * MVw
 
-            _H[1:keep, 1:keep] += Vv * _h[1:keep]'
-            _K[1:keep, 1:keep] += Ww * _k[1:keep]'
+            _H[1:keep, 1:keep] += Vv * transpose(_h[1:keep])
+            _K[1:keep, 1:keep] += Ww * transpose(_k[1:keep])
 
             # newresidual = (I - Vm Vm*) oldresidual = (I - Vl Q1 Vm*) oldresidual = oldresidual + Vl Q1 Q_1^* MWv = oldresidual + Vl Q1 Vv
             Q1Vv = Q[:, 1:keep] * Vv

--- a/src/eigsolve/biarnoldi.jl
+++ b/src/eigsolve/biarnoldi.jl
@@ -1,0 +1,253 @@
+function eigsolve(A, AH, v₀, w₀, howmany::Int, which::Selector, alg::BiArnoldi;
+                  alg_rrule=alg)
+    S, Q, T, Z, fact, converged, numiter, numops = _schursolve(A, AH, v₀, w₀, howmany,
+                                                               which, alg)
+
+    howmany′ = howmany
+    if eltype(T) <: Real && howmany < length(fact) && T[howmany + 1, howmany] != 0
+        howmany′ += 1
+    elseif size(T, 1) < howmany
+        howmany′ = size(T, 1)
+    end
+    if converged > howmany
+        howmany′ = converged
+    end
+
+    TT = view(T, 1:howmany′, 1:howmany′)
+    SS = view(S, 1:howmany′, 1:howmany′)
+    valuesT = schur2eigvals(TT)
+    valuesS = schur2eigvals(SS)
+
+    # Compute eigenvectors
+    VS = view(Q, :, 1:howmany′) * schur2eigvecs(SS)
+    VT = view(Z, :, 1:howmany′) * schur2eigvecs(TT)
+    vectorsS = let B = basis(fact)[1]
+        [B * v for v in cols(VS)]
+    end
+    vectorsT = let B = basis(fact)[2]
+        [B * v for v in cols(VT)]
+    end
+
+    residualsS = let r = residual(fact)[1]
+        [scale(r, last(v)) for v in cols(VS)]
+    end
+    residualsT = let r = residual(fact)[2]
+        [scale(r, last(v)) for v in cols(VT)]
+    end
+
+    normresidualsS = [normres(fact)[1] * abs(last(v)) for v in cols(VS)]
+    normresidualsT = [normres(fact)[2] * abs(last(v)) for v in cols(VT)]
+
+    if (converged < howmany) && alg.verbosity >= WARN_LEVEL
+        @warn """Arnoldi eigsolve stopped without convergence after $numiter iterations:
+        * $converged eigenvalues converged
+        * norm of residuals = $(normres2string(normresidualsS))
+        * number of operations = $numops"""
+    elseif alg.verbosity >= STARTSTOP_LEVEL
+        @info """Arnoldi eigsolve finished after $numiter iterations:
+        * $converged eigenvalues converged
+        * norm of residuals = $(normres2string(normresidualsS))
+        * number of operations = $numops"""
+    end
+    return (valuesS, valuesT),
+           (vectorsS, vectorsT),
+           (ConvergenceInfo(converged, residualsS, normresidualsS, numiter, numops), ConvergenceInfo(converged, residualsT, normresidualsT, numiter, numops))
+end
+
+function _schursolve(A, AH, v₀, w₀, howmany::Int, which::Selector, alg::BiArnoldi)
+    krylovdim = alg.krylovdim
+    maxiter = alg.maxiter
+    howmany > krylovdim &&
+        error("krylov dimension $(krylovdim) too small to compute $howmany eigenvalues")
+
+    ## FIRST ITERATION: setting up
+    numiter = 1
+    # initialize arnoldi factorization
+    iter = BiArnoldiIterator(A, AH, v₀, w₀, alg.orth)
+    fact = initialize(iter; verbosity=alg.verbosity)
+    numops = 1
+    sizehint!(fact, krylovdim)
+    βv, βw = normres(fact)
+    tol::eltype(βv) = alg.tol
+
+    # allocate storage
+    HH = fill(zero(eltype(fact)), krylovdim + 1, krylovdim)
+    KK = fill(zero(eltype(fact)), krylovdim + 1, krylovdim)
+    QQ = fill(zero(eltype(fact)), krylovdim, krylovdim)
+    ZZ = fill(zero(eltype(fact)), krylovdim, krylovdim)
+
+    # initialize storage
+    K = length(fact) # == 1
+    converged = 0
+    local S, T, Q, Z
+    while true
+        βv, βw = normres(fact)
+        K = length(fact)
+
+        if (βv <= tol || βw <= tol) && K < howmany
+            if alg.verbosity >= WARN_LEVEL
+                msg = "Invariant subspace of dimension $K (up to requested tolerance `tol = $tol`), "
+                msg *= "which is smaller than the number of requested eigenvalues (i.e. `howmany == $howmany`)."
+                @warn msg
+            end
+        end
+        if K == krylovdim || (βv <= tol && βw <= tol) || (alg.eager && K >= howmany) # process
+
+            # Step 1
+            _H = view(HH, 1:K, 1:K)
+            _K = view(KK, 1:K, 1:K)
+            Q = view(QQ, 1:K, 1:K)
+            Z = view(ZZ, 1:K, 1:K)
+            _h = view(HH, K + 1, 1:K)
+            _k = view(KK, K + 1, 1:K)
+
+            copyto!(Q, I)
+            copyto!(Z, I)
+
+            copyto!(_H, rayleighquotient(fact)[1])
+            copyto!(_K, rayleighquotient(fact)[2])
+
+            rV, rW = residual(fact)
+            normalize!(rV)
+            normalize!(rW)
+
+            # Compute the oblique Projection
+            # TODO: This should reuse the old projection after restarting
+            M = fill(zero(eltype(fact)), krylovdim, krylovdim)
+            for i in axes(M, 1)
+                for j in axes(M, 2)
+                    M[i, j] = dot(fact.W[i], fact.V[j])
+                end
+            end
+
+            # Step 2 and 3 - Correct H, K and the residuals using the oblique projection
+
+            # Compute the projections W* residual(V) and V* residual(W)
+            Wv = zeros(krylovdim)
+            Vw = zeros(krylovdim)
+            for i in eachindex(Wv)
+                Wv[i] = dot(fact.W[i], rV)
+                Vw[i] = dot(fact.V[i], rW)
+            end
+
+            MWv = inv(M) * Wv
+            MVw = inv(M') * Vw
+
+            _H[:, end] += MWv * βv
+            _K[:, end] += MVw * βw
+
+            for i in eachindex(Wv)
+                rV -= fact.V[i] * MWv[i]
+                rW -= fact.W[i] * MVw[i]
+            end
+
+            # Step 5 - Compute dense schur factorization
+            S, Q, valuesH = hschur!(_H, Q)
+            T, Z, valuesK = hschur!(_K, Z)
+
+            # Step 6 - Order the Schur decompositions
+            by, rev = eigsort(which)
+            pH = sortperm(valuesH; by=by, rev=rev)
+            pK = sortperm(valuesK; by=by, rev=rev)
+
+            S, Q = permuteschur!(S, Q, pH)
+            T, Z = permuteschur!(T, Z, pK)
+
+            # Partially Step 7 & 8 - Correction of hm and km
+            _h = mul!(_h, view(Q, K, :), βv)
+            _k = mul!(_k, view(Z, K, :), βw)
+
+            converged = 0
+            # TODO: this needs refinement
+            while converged < length(fact) && abs(_h[converged + 1]) <= tol &&
+                      abs(_k[converged + 1]) <= tol
+                converged += 1
+            end
+            if eltype(T) <: Real &&
+               0 < converged < length(fact) &&
+               T[converged + 1, converged] != 0
+                converged -= 1
+            end
+
+            if converged >= howmany || (βv <= tol && βw <= tol)
+                break
+            elseif alg.verbosity >= EACHITERATION_LEVEL
+                @info "Arnoldi schursolve in iteration $numiter, step = $K: $converged values converged, normres = $(normres2string(abs.(_h[1:howmany])))"
+            end
+        end
+
+        if K < krylovdim # expand
+            fact = expand!(iter, fact; verbosity=alg.verbosity)
+            numops += 1
+        else # shrink
+            numiter == maxiter && break
+
+            # Determine how many to keep
+            keep = div(3 * krylovdim + 2 * converged, 5) # strictly smaller than krylovdim since converged < howmany <= krylovdim, at least equal to converged
+            while keep < krylovdim &&
+                (isapprox(valuesH[pH[keep]], conj(valuesH[pH[keep + 1]]); rtol=1e-3) ||
+                 isapprox(valuesK[pK[keep]], conj(valuesK[pK[keep + 1]]); rtol=1e-3))
+                # increase the number of eigenvalues kept such that the eigenspace is not fractured at a eigenvalue pair
+                keep += 1
+            end
+
+            # Setp 10 & 11 - Correct the kept part of H and K and the residual 
+
+            # We know that 
+            #   Vm* residual(V) = Q_1* (Vl* residual(V)) = Q_1* Vl* (residual - Vl Ml^-1 Wl* residual) = -Q_1* Ml^-1 Wl* residual = -Q_1* MWv 
+            # as Vl*Vl = Id and Vl* residual = 0
+
+            Vv = -adjoint(Q[:, 1:keep]) * MWv
+            Ww = -adjoint(Z[:, 1:keep]) * MVw
+
+            _H[1:keep, 1:keep] += Vv * _h[1:keep]'
+            _K[1:keep, 1:keep] += Ww * _k[1:keep]'
+
+            # newresidual = (I - Vm Vm*) oldresidual = (I - Vl Q1 Vm*) oldresidual = oldresidual + Vl Q1 Q_1^* MWv = oldresidual + Vl Q1 Vv
+            Q1Vv = Q[:, 1:keep] * Vv
+            Z1Ww = Z[:, 1:keep] * Ww
+
+            for i in eachindex(Q1Vv)
+                rV -= fact.V[i] * Q1Vv[i]
+                rW -= fact.W[i] * Z1Ww[i]
+            end
+
+            βpv = norm(rV)
+            βpw = norm(rW)
+
+            _h .*= βpv
+            _k .*= βpw
+
+            # Restore Arnoldi form in the first keep columns; this is not part of the original paper
+            _restorearnoldiformandupdatebasis!(keep, _H, Q, _h, rayleighquotient(fact)[1],
+                                               fact.V, rV, βpv)
+            _restorearnoldiformandupdatebasis!(keep, _K, Z, _k, rayleighquotient(fact)[2],
+                                               fact.W, rW, βpw)
+
+            # Shrink Arnoldi factorization
+            fact = shrink!(fact, keep; verbosity=alg.verbosity)
+            numiter += 1
+        end
+    end
+
+    return S, Q, T, Z, fact, converged, numiter, numops
+end
+
+function _restorearnoldiformandupdatebasis!(keep, H, U, f, rq, B, r, βr)
+    @inbounds for j in 1:keep
+        H[keep + 1, j] = f[j]
+    end
+    @inbounds for j in keep:-1:1
+        h, ν = householder(H, j + 1, 1:j, j)
+        H[j + 1, j] = ν
+        H[j + 1, 1:(j - 1)] .= 0
+        lmul!(h, H)
+        rmul!(view(H, 1:j, :), h')
+        rmul!(U, h')
+    end
+    copyto!(rq, H) # copy back into fact
+
+    # Update B by applying U
+    basistransform!(B, view(U, :, 1:keep))
+    return B[keep + 1] = scale!!(r, 1 / βr)
+end

--- a/src/factorizations/biarnoldi.jl
+++ b/src/factorizations/biarnoldi.jl
@@ -1,0 +1,187 @@
+# biarnoldi.jl
+mutable struct BiArnoldiFactorization{T,S} <: KrylovFactorization{T,S}
+    k::Int # current Krylov dimension
+    V::OrthonormalBasis{T} # basis of length k
+    W::OrthonormalBasis{T} # basis of length k
+    H::Vector{S} # stores the Hessenberg matrix in packed form
+    K::Vector{S} # stores the Hessenberg matrix in packed form
+    rV::T # residual
+    rW::T # residual
+end
+
+Base.length(F::BiArnoldiFactorization) = F.k
+Base.sizehint!(F::BiArnoldiFactorization, n) = begin
+    sizehint!(F.V, n)
+    sizehint!(F.W, n)
+    sizehint!(F.H, (n * n + 3 * n) >> 1)
+    sizehint!(F.K, (n * n + 3 * n) >> 1)
+    return F
+end
+Base.eltype(F::BiArnoldiFactorization) = eltype(typeof(F))
+Base.eltype(::Type{<:BiArnoldiFactorization{<:Any,S}}) where {S} = S
+
+basis(F::BiArnoldiFactorization) = (F.V, F.W)
+function rayleighquotient(F::BiArnoldiFactorization)
+    return (PackedHessenberg(F.H, F.k), PackedHessenberg(F.K, F.k))
+end
+residual(F::BiArnoldiFactorization) = (F.rV, F.rW)
+@inbounds normres(F::BiArnoldiFactorization) = (abs(F.H[end]), abs(F.K[end]))
+rayleighextension(F::BiArnoldiFactorization) = SimpleBasisVector(F.k, F.k)
+
+struct BiArnoldiIterator{F,T,O<:Orthogonalizer} <: KrylovIterator{F,T}
+    operator::F
+    operatorH::F
+    v₀::T
+    w₀::T
+    orth::O
+end
+BiArnoldiIterator(A, AH, v₀, w₀) = BiArnoldiIterator(A, AH, v₀, w₀, KrylovDefaults.orth)
+
+Base.IteratorSize(::Type{<:BiArnoldiIterator}) = Base.SizeUnknown()
+Base.IteratorEltype(::Type{<:BiArnoldiIterator}) = Base.EltypeUnknown()
+
+function Base.iterate(iter::BiArnoldiIterator)
+    state = initialize(iter)
+    return state, state
+end
+function Base.iterate(iter::BiArnoldiIterator, state)
+    nr = normres(state)
+    if nr < eps(typeof(nr))
+        return nothing
+    else
+        state = expand!(iter, deepcopy(state))
+        return state, state
+    end
+end
+
+function _initializebasis(op, x₀, orth; verbosity::Int=KrylovDefaults.verbosity[])
+    # initialize without using eltype
+
+    β₀ = norm(x₀)
+    iszero(β₀) && throw(ArgumentError("initial vector should not have norm zero"))
+    Ax₀ = apply(op, x₀)
+    α = inner(x₀, Ax₀) / (β₀ * β₀)
+    T = typeof(α) # scalar type of the Rayleigh quotient
+    # this line determines the vector type that we will henceforth use
+    # vector scalar type can be different from `T`, e.g. for real inner products
+    v = add!!(scale(Ax₀, zero(α)), x₀, 1 / β₀)
+    if typeof(Ax₀) != typeof(v)
+        r = add!!(zerovector(v), Ax₀, 1 / β₀)
+    else
+        r = scale!!(Ax₀, 1 / β₀)
+    end
+    βold = norm(r)
+    r = add!!(r, v, -α)
+    β = norm(r)
+    # possibly reorthogonalize
+    if orth isa Union{ClassicalGramSchmidt2,ModifiedGramSchmidt2}
+        dα = inner(v, r)
+        α += dα
+        r = add!!(r, v, -dα)
+        β = norm(r)
+    elseif orth isa Union{ClassicalGramSchmidtIR,ModifiedGramSchmidtIR}
+        while eps(one(β)) < β < iter.orth.η * βold
+            βold = β
+            dα = inner(v, r)
+            α += dα
+            r = add!!(r, v, -dα)
+            β = norm(r)
+        end
+    end
+    V = OrthonormalBasis([v])
+    H = T[α, β]
+    if verbosity > EACHITERATION_LEVEL
+        @info "Arnoldi initiation at dimension 1: subspace normres = $(normres2string(β))"
+    end
+
+    return V, H, r
+end
+
+function initialize(iter::BiArnoldiIterator; verbosity::Int=KrylovDefaults.verbosity[])
+    V, H, rv = _initializebasis(iter.operator, iter.v₀, iter.orth; verbosity)
+    W, K, rw = _initializebasis(iter.operatorH, iter.w₀, iter.orth; verbosity)
+
+    return BiArnoldiFactorization(1, V, W, H, K, rv, rw)
+end
+
+function _initializebasis!(op, x₀, V, H, orth; verbosity)
+    while length(V) > 1
+        pop!(V)
+    end
+    H = empty!(H)
+
+    V[1] = scale!!(V[1], x₀, 1 / norm(x₀))
+    w = apply(op, V[1])
+    r, α = orthogonalize!!(w, V[1], orth)
+    β = norm(r)
+    # state.k = 1
+    push!(H, α, β)
+    # state.r = r
+    if verbosity > EACHITERATION_LEVEL
+        @info "Arnoldi initiation at dimension 1: subspace normres = $(normres2string(β))"
+    end
+
+    return r
+end
+
+function initialize!(iter::BiArnoldiIterator, state::BiArnoldiFactorization;
+                     verbosity::Int=KrylovDefaults.verbosity[])
+    state.rV = _initializebasis!(iter.operator, iter.v₀, iter.V, iter.H, iter.orth;
+                                 verbosity)
+    state.rW = _initializebasis!(iter.operatorH, iter.w₀, iter.W, iter.K, iter.orth;
+                                 verbosity)
+
+    return state
+end
+
+function _expand!(op, k, V, H, r, β, orth; verbosity)
+    push!(V, scale(r, 1 / β))
+    m = length(H)
+    resize!(H, m + k + 1)
+    r, β = arnoldirecurrence!!(op, V, view(H, (m + 1):(m + k)), orth)
+    H[m + k + 1] = β
+    # state.r = r
+    if verbosity > EACHITERATION_LEVEL
+        @info "Arnoldi expansion to dimension $k: subspace normres = $(normres2string(β))"
+    end
+
+    r
+end
+
+function expand!(iter::BiArnoldiIterator, state::BiArnoldiFactorization;
+                 verbosity::Int=KrylovDefaults.verbosity[])
+    state.k += 1
+
+    βv, βw = normres(state)
+    state.rV = _expand!(iter.operator, state.k, state.V, state.H, state.rV, βv, iter.orth; verbosity)
+    state.rW = _expand!(iter.operatorH, state.k, state.W, state.K, state.rW, βw, iter.orth; verbosity)
+    
+    return state
+end
+
+function _shrink!(V, H, k)
+    while length(V) > k + 1
+        pop!(V)
+    end
+    r = pop!(V)
+    resize!(H, (k * k + 3 * k) >> 1)
+    
+    return r
+end
+
+function shrink!(state::BiArnoldiFactorization, k; verbosity::Int=KrylovDefaults.verbosity[])
+    length(state) <= k && return state
+
+    state.k = k
+    rV = _shrink!(state.V, state.H, k)
+    rW = _shrink!(state.W, state.K, k)
+    
+    βv, βw = normres(state)
+    if verbosity > EACHITERATION_LEVEL
+        @info "Arnoldi reduction to dimension $k: subspace normres v = $(normres2string(βv)), w = $(normres2string(βw))"
+    end
+    state.rV = scale!!(rV, βv)
+    state.rW = scale!!(rW, βw)
+    
+    return state
+end


### PR DESCRIPTION
I've added an implementation of the Two-sided Krylov-Schur Restarted Arnoldi method in Ref. [1, Alg. 2] to KrylovKit.jl. The implementation is not done yet and needs some improvements (e.g., unit tests and an update to the convergence criterion). 

It is currently only tested for finding the smallest real eigenvalue :SR for dense Julia matrices. The interface is as close as possible to the other methods, i.e., for a dense matrix A calling 
`eigsolve(A, collect(adjoint(A)), v0, w0, 4, :SR, BiArnoldi(; krylovdim=20, verbosity=10, maxiter=100))`
yields the 4 smallest real value left and right eigenvalues, vectors and convergence information.

Are you interested in merging this into KrylovKit.jl? If so, what should I additionally add (next to tests and the improved convergence criterion)?

I'm interested in using this method downstream (in ITensors.jl) and hence incorporating this into the package would be very much appreciated. I'm willing to do the extra work required, if it is not too much.

Thanks for your work!

[1] Krylov-Schur-Type Restarts for the Two-Sided Arnoldi Method, Ian N. Zwaan and Michiel E. Hochstenbach