### PR TITLE
Avoid creating dense, `SparseVector` `x₀` in `eigsolve` if `A` is `SparseMatrixCSC` etc.

### DIFF
--- a/src/eigsolve/eigsolve.jl
+++ b/src/eigsolve/eigsolve.jl
@@ -186,7 +186,7 @@ function eigsolve(A::AbstractMatrix,
                   which::Selector=:LM,
                   T::Type=eltype(A);
                   kwargs...)
-    x₀ = Random.rand!(similar(A, T, size(A, 1)))
+    x₀ = rand(T, size(A, 1))
     return eigsolve(A, x₀, howmany, which; kwargs...)
 end
 


### PR DESCRIPTION
Solves #126