### PR TITLE
Improve scalartype determination at start of algorithms

### DIFF
--- a/src/eigsolve/eigsolve.jl
+++ b/src/eigsolve/eigsolve.jl
@@ -207,15 +207,8 @@ function eigsolve(
     return eigsolve(f, rand(T, n), howmany, which; kwargs...)
 end
 function eigsolve(f, x₀, howmany::Int = 1, which::Selector = :LM; kwargs...)
-    Tx = typeof(x₀)
-    if Tx <: Block
-        α₀ = inner(x₀[1], apply(f, x₀[1]))
-        T = typeof(α₀)
-    else
-        α₀ = inner(x₀, apply(f, x₀))
-        T = typeof(α₀)
-    end
-    alg = eigselector(f, T; Tx = Tx, kwargs...)
+    T = apply_scalartype(f, x₀)
+    alg = eigselector(f, T; Tx = typeof(x₀), kwargs...)
     checkwhich(which) || error("Unknown eigenvalue selector: which = $which")
     if alg isa Lanczos || alg isa BlockLanczos
         if which == :LI || which == :SI

--- a/src/eigsolve/geneigsolve.jl
+++ b/src/eigsolve/geneigsolve.jl
@@ -187,13 +187,7 @@ function geneigsolve(
 end
 
 function geneigsolve(f, x₀, howmany::Int = 1, which::Selector = :LM; kwargs...)
-    Tx = typeof(x₀)
-    Tfx = Core.Compiler.return_type(genapply, Tuple{typeof(f), Tx}) # should be a tuple type
-    Tfx1 = Base.tuple_type_head(Tfx)
-    Tfx2 = Base.tuple_type_head(Base.tuple_type_tail(Tfx))
-    T1 = Core.Compiler.return_type(dot, Tuple{Tx, Tfx1})
-    T2 = Core.Compiler.return_type(dot, Tuple{Tx, Tfx2})
-    T = promote_type(T1, T2)
+    T = genapply_scalartype(f, x₀)
     alg = geneigselector(f, T; kwargs...)
     if alg isa GolubYe && (which == :LI || which == :SI)
         error("Eigenvalue selector which = $which invalid: real eigenvalues expected with Lanczos algorithm")

--- a/src/factorizations/blocklanczos.jl
+++ b/src/factorizations/blocklanczos.jl
@@ -38,6 +38,8 @@ LinearAlgebra.norm(b::Block) = norm(b.vec)
 
 apply(f, block::Block) = Block(map(Base.Fix1(apply, f), block.vec))
 
+apply_scalartype(f, x₀::Block, as::Number...) = apply_scalartype(f, first(x₀), as...)
+
 function block_inner(B₁::Block{T}, B₂::Block{T}) where {T}
     m₁₁ = inner(B₁[1], B₂[1])
     M = Matrix{typeof(m₁₁)}(undef, length(B₁), length(B₂))

--- a/src/linsolve/linsolve.jl
+++ b/src/linsolve/linsolve.jl
@@ -110,8 +110,7 @@ function linsolve(f, b, a₀::Number = 0, a₁::Number = 1; kwargs...)
 end
 
 function linsolve(f, b, x₀, a₀::Number = 0, a₁::Number = 1; kwargs...)
-    α₀ = inner(x₀, apply(f, x₀))
-    T = typeof(α₀)
+    T = apply_scalartype(f, x₀, a₀, a₁)
     alg = linselector(f, b, T; kwargs...)
     if haskey(kwargs, :alg_rrule)
         alg_rrule = kwargs[:alg_rrule]


### PR DESCRIPTION
Here I tried to slightly more carefully treat determining the scalartype that will be used in the algorithms.
Importantly, I attempted to reinstate the type inference as a first attempt, since it would be nice to avoid having to do a function evaluation and allocations etc when this is not necessary.
Nevertheless, this still retains fallback solutions for when type inference fails, and should also still error at a reasonable place when the function fails itself.
I also added this behavior to the generalized eigenvalue solvers.

This should also fully fix #132, which technically already was more or less fixed before.
We might have to add some additional tests for this though, but I'm not sure what the best way is to construct things that are type unstable in a reliable way.