### PR TITLE
Pass correct views to `SymTridiagonal`

### DIFF
--- a/src/factorizations/lanczos.jl
+++ b/src/factorizations/lanczos.jl
@@ -50,7 +50,9 @@ function basis(F::LanczosFactorization)
     return length(F.V) == F.k ? F.V :
         error("Not keeping vectors during Lanczos factorization")
 end
-rayleighquotient(F::LanczosFactorization) = SymTridiagonal(F.αs, F.βs)
+function rayleighquotient(F::LanczosFactorization)
+    return SymTridiagonal(view(F.αs, 1:(F.k)), view(F.βs, 1:(F.k - 1)))
+end
 residual(F::LanczosFactorization) = F.r
 @inbounds normres(F::LanczosFactorization) = F.βs[F.k]
 rayleighextension(F::LanczosFactorization) = SimpleBasisVector(F.k, F.k)

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -27,3 +27,10 @@ end
     @test info.numops == 2
     @test info.normres == 0.0
 end
+
+# https://github.com/Jutho/KrylovKit.jl/issues/156
+@testset "Issue #156" begin
+    vals, vecs, info = eigsolve([1 0; 0 1])
+    @test info.converged ≥ 1
+    @test all(≈(1.0), vals[1:(info.converged)])
+end


### PR DESCRIPTION
This PR fixes #156.

We were simply missing a correct view of the current sizes.
Interestingly, this was already handled correctly in the other parts of the code:
https://github.com/Jutho/KrylovKit.jl/blob/4b47482bf3f6a0f9007525e0f5490256be74dbbf/src/factorizations/gkl.jl#L77-L79

This should actually already have been an issue in cases where the `rayleighquotient(fact)` is called on an "incomplete" factorization, as then it would not even be a matrix of the right size, but seemingly this just never happened.